### PR TITLE
use sdk 0.8.0 or newer instead of main

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM quay.io/centos/centos:stream8
 
-RUN dnf -y module install python39 && dnf -y install python39 python39-pip git
+RUN dnf -y module install python39 && dnf -y install python39 python39-pip
 RUN mkdir /app
 # this is to satisfy arcaflow-plugin-image-builder but the local license file is the same.
 ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /app

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-git+https://github.com/arcalot/arcaflow-plugin-sdk-python.git@main
+arcaflow-plugin-sdk>=0.8.0
 coverage


### PR DESCRIPTION
## Changes introduced with this PR

Now that 0.8.0 has been released, use the pypi version of the sdk instead of the github@main one.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).

Signed-off-by: Sandro Bonazzola <sbonazzo@redhat.com>