### PR TITLE
updating Dockerfile License file location and using only apache 2.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM quay.io/centos/centos:stream8
 RUN dnf -y module install python39 && dnf --setopt=tsflags=nodocs -y install python39 python39-pip && dnf clean all
 RUN mkdir /app
 # this is to satisfy arcaflow-plugin-image-builder but the local license file is the same.
-ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugins/main/LICENSE /app/
+ADD https://raw.githubusercontent.com/arcalot/arcaflow-plugin-template-python/main/LICENSE /app/
 ADD README.md /app/
 ADD wait_plugin.py /app/
 ADD tests/test_wait_plugin.py /app/
@@ -22,7 +22,7 @@ ENTRYPOINT ["python3", "/app/wait_plugin.py"]
 CMD []
 
 LABEL org.opencontainers.image.source="https://github.com/arcalot/arcaflow-plugin-wait"
-LABEL org.opencontainers.image.licenses="Apache-2.0+GPL-2.0-only"
+LABEL org.opencontainers.image.licenses="Apache-2.0"
 LABEL org.opencontainers.image.vendor="Arcalot project"
 LABEL org.opencontainers.image.authors="Arcalot contributors"
 LABEL org.opencontainers.image.title="Python Wait Plugin"


### PR DESCRIPTION
## Changes introduced with this PR

Updating Dockerfile License file location
Updating License to be Apache-2.0

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).